### PR TITLE
Update sql.bnf to add create statement overrides for use the schema create

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -60,7 +60,7 @@ stmt_list ::= ( stmt SEMI ) * {
   mixin="com.alecstrong.sql.psi.core.psi.mixins.SqlStmtListMixin"
   pin(".*")=1
 }
-stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( extension_stmt | alter_table_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt | create_view_stmt |
+stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( extension_stmt | alter_table_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_extension_stmt | create_schema_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt | create_view_stmt |
                                           create_virtual_table_stmt | delete_stmt_limited | detach_stmt | drop_index_stmt | drop_table_stmt | drop_trigger_stmt | drop_view_stmt | insert_stmt |
                                           pragma_stmt | reindex_stmt | release_stmt | rollback_stmt | savepoint_stmt | compound_select_stmt | update_stmt_limited | vacuum_stmt
                                         ) {
@@ -489,3 +489,7 @@ module_argument_name ::= id
 bind_parameter ::= '?'
 table_options ::= table_option ( [COMMA] table_option ) *
 table_option ::= WITHOUT ROWID
+
+create_stmt_override :: = "__CREATE__"
+create_extension_stmt ::= create_stmt_override
+create_schema_stmt ::= create_stmt_override


### PR DESCRIPTION
Add `CREATE` stubs that can be overridden in dialects where needed to order statements

SqlDelight TreeUtil `forInitializationStatements` is responsible for ordering the sql statements when `schema.create` is generated - https://github.com/cashapp/sqldelight/blob/d7cc00eabc133b43f38a1e75f70af7e786dd00d7/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt#L255

Note:- Migrations don't use this ordering and is preferred way of creating more complex schema 

Currently `CREATE TABLE` statements are ordered first - some database support `CREATE` statements that execute before e.g `CREATE SCHEMA sales` needs to be run before `CREATE TABLE sales.Orders` 

What an updated TreeUtil would look like using the overrides of create statements that may be available

```
  val databases= ArrayList<PsiElement>()
  val views = ArrayList<SqlCreateViewStmt>()
  val tables = ArrayList<SqlCreateTableStmt>()
  val creators = ArrayList<PsiElement>()
  val miscellanious = ArrayList<PsiElement>()

  forEach { file ->
    file.sqlStatements()
      .filter { (label, _) -> label.name == null }
      .forEach { (_, sqlStatement) ->
        when {
          sqlStatement.createSchemaStmt != null -> databases.add(sqlStatement.createSchemaStmt!!)
          sqlStatement.createExtensionStmt != null -> databases.add(sqlStatement.createExtensionStmt!!)
          sqlStatement.createTableStmt != null -> tables.add(sqlStatement.createTableStmt!!)
          sqlStatement.createViewStmt != null -> views.add(sqlStatement.createViewStmt!!)
          sqlStatement.createTriggerStmt != null -> creators.add(sqlStatement.createTriggerStmt!!)
          sqlStatement.createIndexStmt != null -> creators.add(sqlStatement.createIndexStmt!!)
          else -> miscellanious.add(sqlStatement)
        }
      }
  }

  databases.forEach { body(it.rawSqlText()) } // some schema elements must exist before tables
```

e.g Postgresql.bnf would override `create_schema_stmt` with the dialect implementation and TreeUtil would be able to use the statements

```
create_schema_stmt ::= CREATE 'SCHEMA' [ IF NOT EXISTS ] schema_name {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCreateSchemaStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlCreateSchemaStmt"
   override = true
}
```