### PR TITLE
Use Java target to 11

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 23
 
     - name: Setup gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/SNAPSHOT.yml
+++ b/.github/workflows/SNAPSHOT.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 23
 
     - name: Setup gradle
       uses: gradle/actions/setup-gradle@v4

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ allprojects {
 subprojects {
   apply(plugin: "org.jetbrains.kotlin.jvm")
 
-  kotlin.jvmToolchain(17)
-
   tasks.withType(JavaCompile).configureEach {
     sourceCompatibility = '11'
     targetCompatibility = '11'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlinJvm) apply false
   alias(libs.plugins.spotless)
@@ -36,6 +38,17 @@ subprojects {
   apply(plugin: "org.jetbrains.kotlin.jvm")
 
   kotlin.jvmToolchain(17)
+
+  tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = '11'
+    targetCompatibility = '11'
+  }
+
+  tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+      jvmTarget = '11'
+    }
+  }
 
   tasks.withType(Test).configureEach {
     testLogging {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.grammarKitComposer)

--- a/sample-headless/src/test/kotlin/com/alecstrong/sql/psi/sample/headless/SampleHeadlessParserTest.kt
+++ b/sample-headless/src/test/kotlin/com/alecstrong/sql/psi/sample/headless/SampleHeadlessParserTest.kt
@@ -2,8 +2,10 @@ package com.alecstrong.sql.psi.sample.headless
 
 import com.alecstrong.sql.psi.core.psi.SqlLiteralExpr
 import com.alecstrong.sql.psi.sample.core.psi.CustomExpr
-import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import java.io.File
+import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -21,7 +23,7 @@ class SampleHeadlessParserTest {
           stmt.createTableStmt != null -> {
             val createTableStmt = stmt.createTableStmt!!
             for (columnDef in createTableStmt.columnDefList) {
-              val literalExpr = columnDef.childrenOfType<SqlLiteralExpr>().single()
+              val literalExpr = columnDef.childrenOfType(SqlLiteralExpr::class).single()
               assertEquals(42, literalExpr.literalValue.numericLiteral!!.text.toInt())
             }
           }
@@ -32,7 +34,7 @@ class SampleHeadlessParserTest {
             for (expr in exprs) {
               if (expr is CustomExpr) {
                 val fooRule = expr.fooRule
-                val literalExpr = fooRule.childrenOfType<SqlLiteralExpr>().single().childrenOfType<SqlLiteralExpr>().single()
+                val literalExpr = fooRule.childrenOfType(SqlLiteralExpr::class).single().childrenOfType(SqlLiteralExpr::class).single()
                 assertEquals(13, literalExpr.literalValue.numericLiteral!!.text.toInt())
               }
             }
@@ -42,3 +44,5 @@ class SampleHeadlessParserTest {
     }
   }
 }
+
+fun <T : PsiElement> PsiElement.childrenOfType(kClass: KClass<T>): List<T> = PsiTreeUtil.getChildrenOfTypeAsList(this, kClass.java)


### PR DESCRIPTION
SqlDelight is forced to use Java 17 for the Gradle plugin due sql-psi `core` dependency.

This PR changes the target Java version to 11, but it still will use Java 17 in the toolchain as it has better build speed.

If you agree, upgrading the toolchain to Java 21 can be interesting as it should be faster.