### PR TITLE
Fix 666 LIKE ... ESCAPE ... AND ...

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -213,7 +213,6 @@ expr ::= ( other_expr
          | binary_or_expr
          | binary_and_expr
          | between_expr
-         | binary_like_expr
          | is_distinct_from_expr // needs to go before is_expr because it starts the same
          | is_expr
          | null_expr
@@ -221,6 +220,9 @@ expr ::= ( other_expr
          | cast_expr
          | function_expr
          | in_expr
+         | bind_expr
+         | like_escape_character_expr // The ESCAPE clause (with its escape character) acts as a single postfix operator
+         | binary_like_expr
          | binary_equality_expr
          | binary_boolean_expr
          | binary_bitwise_expr
@@ -229,8 +231,7 @@ expr ::= ( other_expr
          | binary_pipe_expr
          | unary_expr
          | literal_expr
-         | column_expr
-         | bind_expr )
+         | column_expr)
 
 other_expr ::= extension_expr
 extension_expr ::= FAKE_EXTENSION
@@ -284,7 +285,8 @@ paren_expr ::= LP expr RP {
 cast_expr ::= CAST LP expr AS type_name RP
 collate_expr ::= expr COLLATE collation_name
 binary_like_operator ::= ( LIKE | GLOB | REGEXP | MATCH )
-binary_like_expr ::= expr [ NOT ] ( binary_like_operator ) expr [ ESCAPE expr ] {
+like_escape_character_expr ::= ESCAPE expr
+binary_like_expr ::= expr [ NOT ] binary_like_operator expr [ like_escape_character_expr ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryLikeExprMixin"
 }
 null_expr ::= expr ( ISNULL | NOTNULL | NOT NULL )


### PR DESCRIPTION
fixes #666 😈 

Output a correct PSI tree for `url LIKE :urlLike ESCAPE :escape AND itemId = :itemId AND channelId =:channelId;`

```
SqlBinaryAndExprImpl(BINARY_AND_EXPR)
├── SqlBinaryLikeExprImpl(BINARY_LIKE_EXPR)
│   ├── SqlColumnExprImpl(COLUMN_EXPR) "url"
│   ├── SqlBindExprImpl(BIND_EXPR) ":urlLike"
│   └── SqlBindExprImpl(BIND_EXPR) ":escape" (optional ESCAPE clause)
└── SqlBinaryAndExprImpl(BINARY_AND_EXPR)
    ├── SqlBinaryEqualityExprImpl(BINARY_EQUALITY_EXPR)
    │   ├── SqlColumnExprImpl(COLUMN_EXPR) "itemId"
    │   └── SqlBindExprImpl(BIND_EXPR) ":itemId"
    └── SqlBinaryEqualityExprImpl(BINARY_EQUALITY_EXPR)
        ├── SqlColumnExprImpl(COLUMN_EXPR) "channelId"
        └── SqlBindExprImpl(BIND_EXPR) ":channelId"
```

Currently the problem is that `:escape AND itemId ` bind together instead of `url LIKE :urlLike ESCAPE :escape`

The optional The ESCAPE clause (with its escape character) acts as a single postfix operator. It can only bind to a preceding [expr] LIKE [expr] expression

A new like_escape_character_expr is needed  for correct structure to create an expression that must be assigned a TEXT type in sqldelight.

The bind_expr needs to have higher precedence for the correct PSI tree

The like() function is used to implement the "Y LIKE X [ESCAPE Z]" expression. If the optional ESCAPE clause is present, then the like() function is invoked with three arguments. Otherwise, it is invoked with two arguments only. Note that the X and Y parameters are reversed in the like() function relative to the infix [LIKE](https://www.sqlite.org/lang_expr.html#like) operator. X is the pattern and Y is the string to match against that pattern
 
* SqlDelight will need https://github.com/griffio/sqldelight/tree/fix-5716-like-escape-inferred-type once new version of sql-psi is released