### PR TITLE
Fix 668 missing JOIN CONSTRAINT

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -390,7 +390,7 @@ full_join_operator ::= FULL
 
 join_operator ::= ( COMMA
                   | [ NATURAL ] [ left_join_operator [ OUTER ] | INNER | CROSS ] JOIN )
-join_constraint ::= ON expr | USING LP column_name ( COMMA column_name ) * RP
+join_constraint ::= [ ON expr | USING LP column_name ( COMMA column_name ) * RP ]
 ordering_term ::= expr [ COLLATE collation_name ] [ ASC | DESC ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.OrderByMixin"
 }


### PR DESCRIPTION
fixes #668 🤷 

This is the quickest fix to restore previous behaviour 

Add back the optional join_constraint - seems to create the missing join condition needed by `com.alecstrong.sql.psi.core.psi.mixins.JoinClauseMixin`

Note - We don't need to remove the other uses of optional join_constraint

Tested sql-psi snapshot with SqlDelight