### PR TITLE
Set system properties to suppress warnings

### DIFF
--- a/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
+++ b/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
@@ -40,6 +40,11 @@ private class ApplicationEnvironment {
   val disposable = Disposer.newDisposable()
 
   val coreApplicationEnvironment: CoreApplicationEnvironment = CoreApplicationEnvironment(disposable).apply {
+
+    System.setProperty("ide.hide.excluded.files", "false")
+    System.setProperty("psi.sleep.in.validity.check", "false")
+    System.setProperty("psi.incremental.reparse.depth.limit", "1000")
+
     CoreApplicationEnvironment.registerApplicationExtensionPoint(
       MetaLanguage.EP_NAME,
       MetaLanguage::class.java,


### PR DESCRIPTION
fixes #https://github.com/sqldelight/sqldelight/issues/5749

Add default values from https://github.com/JetBrains/intellij-community/blob/master/platform/util/resources/misc/registry.properties

Tested with SqlDelight compiler tests - with and without changes

Changes made to sql-psi can be tested with SqlDelight by adding in settings.gradle

```
includeBuild('../sql-psi') {
  dependencySubstitution {
    substitute(module("app.cash.sql-psi:core")).using(project(":core"))
    substitute(module("app.cash.sql-psi:environment")).using(project(":environment"))
  }
}
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
