### PR TITLE
Change visibility for inheritance

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
@@ -55,9 +55,9 @@ internal abstract class CreateIndexMixin(
   }
 }
 
-internal class CreateIndexElementType(
+open class CreateIndexElementType(
   name: String,
 ) : SqlSchemaContributorElementType<SqlCreateIndexStmt>(name, SqlCreateIndexStmt::class.java) {
-  override fun nameType() = SqlTypes.TABLE_NAME
+  override fun nameType() = SqlTypes.INDEX_NAME
   override fun createPsi(stub: SchemaContributorStub) = SqlCreateIndexStmtImpl(stub, this)
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateViewMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateViewMixin.kt
@@ -65,7 +65,7 @@ internal abstract class CreateViewMixin(
   }
 }
 
-internal class CreateViewElementType(name: String) :
+open class CreateViewElementType(name: String) :
   SqlSchemaContributorElementType<TableElement>(name, TableElement::class.java) {
   override fun nameType() = SqlTypes.VIEW_NAME
   override fun createPsi(stub: SchemaContributorStub) = SqlCreateViewStmtImpl(stub, this)


### PR DESCRIPTION
( supports https://github.com/sqldelight/sqldelight/pull/5772 )

This allows SqlDelight PostgreSql dialect to have access for new indexing element types 
`Please add the class app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateIndexElementType with external ID sqldelight.null containing stub element type constants to "stubElementTypeHolder" extension.`

Similar to Sqlite 3.18 dialect uses https://github.com/sqldelight/sql-psi/blob/9b2c76d1ff3250db34c0438f57253b979321819c/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/AlterTableMixin.kt#L131

Fix nameType to INDEX from TABLE - this was likely incorrect ?

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
