### PR TITLE
Fix ResultColumnMixin - add table reference for QueryResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix ResultColumnMixin - add table reference for QueryResult https://github.com/sqldelight/sql-psi/pull/687
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
 - Fix unwanted environment log warnings https://github.com/sqldelight/sql-psi/pull/679
 

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
@@ -44,7 +44,7 @@ internal abstract class ResultColumnMixin(
     }
 
     return@lazy queryAvailable.fold(emptyList<QueryResult>()) { left, right ->
-      left + right.copy(table = null, columns = right.columns.filter { !it.hiddenByUsing })
+      left + right.copy(table = right.table, columns = right.columns.filter { !it.hiddenByUsing })
     }
   }
 


### PR DESCRIPTION
`QueryResult.table` was being hardcoded as `null`, add the table reference so that `queryExposed()` collection elements `QueryResult.table` can be used to determine the result column's table or table alias.

e.g Query Table reference could also be a TableAlias element.

```sql
SELECT *
FROM Orders o
JOIN OrderLines ol USING (order_id)
```
---

- [X] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
