### PR TITLE
Fix for Sql-Psi SqlCoreEnvironment

### DIFF
--- a/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
+++ b/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
@@ -76,8 +76,8 @@ open class SqlCoreEnvironment(
     env.coreApplicationEnvironment,
   )
 
-  private val localFileSystem: VirtualFileSystem = StandardFileSystems.local()
-  private val jarFileSystem: VirtualFileSystem = StandardFileSystems.jar()
+  protected val localFileSystem: VirtualFileSystem = StandardFileSystems.local()
+  protected val jarFileSystem: VirtualFileSystem = StandardFileSystems.jar()
 
   init {
     projectEnvironment.registerProjectComponent(
@@ -225,7 +225,7 @@ private class CoreFileIndex(
           val jarFilePath = file.toUri().toString().removePrefix("jar:file://")
           jarFileSystem.findFileByPath(jarFilePath)
         }
-        StandardFileSystems.FILE_PROTOCOL -> localFileSystems.findFileByPath(file.pathString)
+        StandardFileSystems.FILE_PROTOCOL -> localFileSystems.findFileByPath(file.toAbsolutePath().toString())
         else -> error("Not supported schema $schema")
       } ?: throw NullPointerException("File ${file.pathString} not found")
 


### PR DESCRIPTION
Currently `sql-psi` breaks SqlDelight - main reason is that `localFileSystem`, `jarFileSystem` were private. 

Make `localFileSystem`, `jarFileSystem` protected as they are inherited properties in SqlDelight
Unless there is some reason due to Isolation for these to be private ?

Fix SqlDelight fixture tests with `file.toAbsolutePath` as the relative path breaks all tests in SqlDelight

Note:
SqlDelight will require some minor changes to take this `sql-psi` version as it is not a compatible version, that will be done once this new version is published and can be tried out.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
