### PR TITLE
Support extension schema contributors with IndexElement

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
@@ -7,6 +7,7 @@ import com.alecstrong.sql.psi.core.psi.SchemaContributorIndex
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateTriggerStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
+import com.alecstrong.sql.psi.core.psi.SqlExtensionStmt
 import com.alecstrong.sql.psi.core.psi.SqlStmtList
 import com.alecstrong.sql.psi.core.psi.TableElement
 import com.intellij.extapi.psi.PsiFileBase
@@ -117,7 +118,7 @@ abstract class SqlFileBase(viewProvider: FileViewProvider, language: Language) :
       for ((baseContributorIndex, baseContributor) in baseContributorFiles.withIndex()) {
         // Put the last file to index -1, and the previous files to previous index.
         val orderedIndex = -1 - baseContributorFiles.lastIndex + baseContributorIndex.toLong()
-        baseContributor.contributors()?.let { contributors ->
+        baseContributor.contributors().let { contributors ->
           orderedContributors[orderedIndex] = linkedSetOf(elements = contributors.toTypedArray())
         }
       }
@@ -129,12 +130,18 @@ abstract class SqlFileBase(viewProvider: FileViewProvider, language: Language) :
     }
 
     contributors()
-      ?.takeWhile { order == null || until == null || it.textOffset <= until.textOffset }
-      ?.forEach { block(it) }
+      .takeWhile { order == null || until == null || it.textOffset <= until.textOffset }
+      .forEach { block(it) }
   }
 
-  private fun contributors() =
-    sqlStmtList?.stmtList?.mapNotNull { it.firstChild as? SchemaContributor }
+  private fun contributors(): List<SchemaContributor> {
+    return sqlStmtList?.stmtList?.mapNotNull { it.firstChild as? SchemaContributor }.orEmpty() +
+      sqlStmtList
+        ?.stmtList
+        ?.mapNotNull { it.firstChild as? SqlExtensionStmt }
+        ?.mapNotNull { it.firstChild as? SchemaContributor }
+        .orEmpty()
+  }
 
   /**
    * Optional files which can be used for extra Schema Contributors that are unindexed. The files

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
@@ -118,7 +118,7 @@ abstract class SqlFileBase(viewProvider: FileViewProvider, language: Language) :
       for ((baseContributorIndex, baseContributor) in baseContributorFiles.withIndex()) {
         // Put the last file to index -1, and the previous files to previous index.
         val orderedIndex = -1 - baseContributorFiles.lastIndex + baseContributorIndex.toLong()
-        baseContributor.contributors().let { contributors ->
+        baseContributor.contributors()?.let { contributors ->
           orderedContributors[orderedIndex] = linkedSetOf(elements = contributors.toTypedArray())
         }
       }
@@ -130,17 +130,19 @@ abstract class SqlFileBase(viewProvider: FileViewProvider, language: Language) :
     }
 
     contributors()
-      .takeWhile { order == null || until == null || it.textOffset <= until.textOffset }
-      .forEach { block(it) }
+      ?.takeWhile { order == null || until == null || it.textOffset <= until.textOffset }
+      ?.forEach { block(it) }
   }
 
-  private fun contributors(): List<SchemaContributor> {
-    return sqlStmtList?.stmtList?.mapNotNull { it.firstChild as? SchemaContributor }.orEmpty() +
-      sqlStmtList
-        ?.stmtList
-        ?.mapNotNull { it.firstChild as? SqlExtensionStmt }
-        ?.mapNotNull { it.firstChild as? SchemaContributor }
-        .orEmpty()
+  private fun contributors(): List<SchemaContributor>? {
+    // Preserve schemaContributor statement ordering and add any schemaContributors that are first
+    // child of SqlExtensionStmt.
+    return sqlStmtList?.stmtList?.mapNotNull { stmt ->
+      stmt.firstChild as? SchemaContributor
+        ?: (stmt.firstChild as? SqlExtensionStmt)?.let { sqlExt ->
+          sqlExt.firstChild as? SchemaContributor
+        }
+    }
   }
 
   /**

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
@@ -1,3 +1,9 @@
 package com.alecstrong.sql.psi.core.psi
 
-interface IndexElement : SqlCompositeElement, SchemaContributor
+/**
+ * IndexElement represents a named index element implemented by CreateIndex, DropIndex, AlterIndex.
+ * The indexElementName can be overridden to return the new name of an AlterIndex element
+ */
+interface IndexElement : SqlCompositeElement, SchemaContributor {
+  fun indexElementName(): String = name()
+}

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
@@ -1,0 +1,3 @@
+package com.alecstrong.sql.psi.core.psi
+
+interface IndexElement : SqlCompositeElement, SchemaContributor

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/IndexElement.kt
@@ -1,9 +1,12 @@
 package com.alecstrong.sql.psi.core.psi
 
+import com.intellij.psi.StubBasedPsiElement
+
 /**
  * IndexElement represents a named index element implemented by CreateIndex, DropIndex, AlterIndex.
  * The indexElementName can be overridden to return the new name of an AlterIndex element
  */
-interface IndexElement : SqlCompositeElement, SchemaContributor {
+interface IndexElement :
+  SqlCompositeElement, SchemaContributor, StubBasedPsiElement<SchemaContributorStub> {
   fun indexElementName(): String = name()
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SchemaContributor.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SchemaContributor.kt
@@ -47,4 +47,16 @@ class Schema {
   @Suppress("UNCHECKED_CAST")
   fun <Value : SchemaContributor> values(type: KClass<Value>) =
     map[type]?.values as Collection<Value>? ?: emptyList()
+
+  fun replace(
+    type: KClass<out SchemaContributor>,
+    name: String,
+    newName: String,
+    value: SchemaContributor,
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    val typedMap = map.getOrPut(type) { linkedMapOf() } as MutableMap<String, SchemaContributor>
+    typedMap.remove(name)
+    typedMap[newName] = value
+  }
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlCompositeElementImpl.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlCompositeElementImpl.kt
@@ -39,7 +39,7 @@ open class SqlCompositeElementImpl(node: ASTNode) :
     }
 }
 
-internal abstract class SqlSchemaContributorImpl<
+abstract class SqlSchemaContributorImpl<
   SchemaType : SchemaContributor,
   ElementType : SqlSchemaContributorElementType<SchemaType>,
 >(stub: SchemaContributorStub?, nodeType: IElementType?, node: ASTNode?) :

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
@@ -46,7 +46,9 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     if (
       node.findChildByType(SqlTypes.EXISTS) == null &&
-        containingFile.schema<IndexElement>(this).any { it != this && it.name() == indexName.text }
+        containingFile.schema<IndexElement>(this).any {
+          it != this && it.indexElementName() == indexName.text
+        }
     ) {
       annotationHolder.createErrorAnnotation(indexName, "Duplicate index name ${indexName.text}")
     }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
@@ -2,6 +2,7 @@ package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlSchemaContributorElementType
+import com.alecstrong.sql.psi.core.psi.IndexElement
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.Schema
 import com.alecstrong.sql.psi.core.psi.SchemaContributorStub
@@ -13,13 +14,11 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.IElementType
 
-internal abstract class CreateIndexMixin(
-  stub: SchemaContributorStub?,
-  nodeType: IElementType?,
-  node: ASTNode?,
-) :
-  SqlSchemaContributorImpl<SqlCreateIndexStmt, CreateIndexElementType>(stub, nodeType, node),
-  SqlCreateIndexStmt {
+internal abstract class CreateIndexMixin
+private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node: ASTNode?) :
+  SqlSchemaContributorImpl<IndexElement, CreateIndexElementType>(stub, nodeType, node),
+  SqlCreateIndexStmt,
+  IndexElement {
   constructor(node: ASTNode) : this(null, null, node)
 
   constructor(stub: SchemaContributorStub, nodeType: IElementType) : this(stub, nodeType, null)
@@ -32,7 +31,7 @@ internal abstract class CreateIndexMixin(
   }
 
   override fun modifySchema(schema: Schema) {
-    schema.put<SqlCreateIndexStmt>(this)
+    schema.put<IndexElement>(this)
   }
 
   override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
@@ -47,9 +46,7 @@ internal abstract class CreateIndexMixin(
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     if (
       node.findChildByType(SqlTypes.EXISTS) == null &&
-        containingFile.schema<SqlCreateIndexStmt>(this).any {
-          it != this && it.indexName.textMatches(indexName)
-        }
+        containingFile.schema<IndexElement>(this).any { it != this && it.name() == indexName.text }
     ) {
       annotationHolder.createErrorAnnotation(indexName, "Duplicate index name ${indexName.text}")
     }
@@ -58,7 +55,7 @@ internal abstract class CreateIndexMixin(
 }
 
 open class CreateIndexElementType(name: String) :
-  SqlSchemaContributorElementType<SqlCreateIndexStmt>(name, SqlCreateIndexStmt::class.java) {
+  SqlSchemaContributorElementType<IndexElement>(name, IndexElement::class.java) {
   override fun nameType() = SqlTypes.INDEX_NAME
 
   override fun createPsi(stub: SchemaContributorStub) = SqlCreateIndexStmtImpl(stub, this)

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateTableMixin.kt
@@ -2,6 +2,7 @@ package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlSchemaContributorElementType
+import com.alecstrong.sql.psi.core.psi.IndexElement
 import com.alecstrong.sql.psi.core.psi.LazyQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.QueryElement.SynthesizedColumn
@@ -120,7 +121,8 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
 
     // Check in file for `CREATE UNIQUE INDEX` statement that matches the given columns.
     containingFile
-      .schema<SqlCreateIndexStmt>() // sqlStmtElement is null to include all statements
+      .schema<IndexElement>()
+      .filterIsInstance<SqlCreateIndexStmt>()
       .filter { it.isUnique() && it.indexedColumnList.all { it.collationName == null } }
       .forEach {
         val indexedColumns =

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
@@ -36,7 +36,7 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
       if (
         node.findChildByType(SqlTypes.EXISTS) == null &&
           containingFile.schema<IndexElement>(this).none {
-            it != this && it.name() == indexName.text
+            it != this && it.indexElementName() == indexName.text
           }
       ) {
         annotationHolder.createErrorAnnotation(

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
@@ -2,9 +2,9 @@ package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlSchemaContributorElementType
+import com.alecstrong.sql.psi.core.psi.IndexElement
 import com.alecstrong.sql.psi.core.psi.Schema
 import com.alecstrong.sql.psi.core.psi.SchemaContributorStub
-import com.alecstrong.sql.psi.core.psi.SqlCreateIndexStmt
 import com.alecstrong.sql.psi.core.psi.SqlDropIndexStmt
 import com.alecstrong.sql.psi.core.psi.SqlSchemaContributorImpl
 import com.alecstrong.sql.psi.core.psi.SqlTypes
@@ -14,7 +14,7 @@ import com.intellij.psi.tree.IElementType
 
 internal abstract class DropIndexMixin
 private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node: ASTNode?) :
-  SqlSchemaContributorImpl<SqlCreateIndexStmt, DropIndexElementType>(stub, nodeType, node),
+  SqlSchemaContributorImpl<IndexElement, DropIndexElementType>(stub, nodeType, node),
   SqlDropIndexStmt {
   constructor(node: ASTNode) : this(null, null, node)
 
@@ -28,15 +28,15 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
   }
 
   override fun modifySchema(schema: Schema) {
-    schema.forType<SqlCreateIndexStmt>().remove(name())
+    schema.forType<IndexElement>().remove(name())
   }
 
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     indexName?.let { indexName ->
       if (
         node.findChildByType(SqlTypes.EXISTS) == null &&
-          containingFile.schema<SqlCreateIndexStmt>(this).none {
-            it != this && it.indexName.textMatches(indexName)
+          containingFile.schema<IndexElement>(this).none {
+            it != this && it.name() == indexName.text
           }
       ) {
         annotationHolder.createErrorAnnotation(
@@ -51,7 +51,7 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
 }
 
 internal class DropIndexElementType(name: String) :
-  SqlSchemaContributorElementType<SqlCreateIndexStmt>(name, SqlCreateIndexStmt::class.java) {
+  SqlSchemaContributorElementType<IndexElement>(name, IndexElement::class.java) {
   override fun nameType() = SqlTypes.TABLE_NAME
 
   override fun createPsi(stub: SchemaContributorStub) = SqlDropIndexStmtImpl(stub, this)

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
@@ -52,7 +52,7 @@ private constructor(stub: SchemaContributorStub?, nodeType: IElementType?, node:
 
 internal class DropIndexElementType(name: String) :
   SqlSchemaContributorElementType<IndexElement>(name, IndexElement::class.java) {
-  override fun nameType() = SqlTypes.TABLE_NAME
+  override fun nameType() = SqlTypes.INDEX_NAME
 
   override fun createPsi(stub: SchemaContributorStub) = SqlDropIndexStmtImpl(stub, this)
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -103,7 +103,7 @@ release_stmt ::= RELEASE [ SAVEPOINT ] savepoint_name {
 }
 create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] [ database_name DOT ] index_name ON table_name LP indexed_column ( COMMA indexed_column ) * RP [ WHERE expr ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.CreateIndexMixin"
-  implements = "com.alecstrong.sql.psi.core.psi.SchemaContributor"
+  implements = "com.alecstrong.sql.psi.core.psi.IndexElement"
   elementTypeClass = "com.alecstrong.sql.psi.core.psi.mixins.CreateIndexElementType"
   stubClass = "com.alecstrong.sql.psi.core.psi.SchemaContributorStub"
   pin = 6


### PR DESCRIPTION
🚧 🏗️  Shows new `IndexElement` type so that indexes are named types that can be stored in the schema and allow the indexElementName to be overridden.

Introduces an `IndexElement` type like `TableElement` as the schema object can then store index names and not specific types like `SqlCreateIndexStmt`, `SqlDropIndexStmt` or `PostgreSqlAlterIndexStmt`.

When PostgreSql dialect implements `PostgreSqlAlterIndexStmt` it is stored as `IndexElement` and can replace the existing `IndexElement` with a new name. 

* Introduces `Schema.replace(...)`, that is public and not inlined, to remove and then add type with a new name.

For the IDEA plugin to work with the new `ALTER INDEX` mixin, a stub must be created,  `SqlSchemaContributorImpl` is made public similar to `SqlCompositeElementImpl`.

TODO 
* More testing with SqlDelight as `IndexElement` must be implemented by dialects and change any calls to `schema<SqlCreateIndexStmt>` with `schema<TableElement>` 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
