### PR TITLE
sql.bnf - support ANY/ALL operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a compilation error with migration files when CREATE UNIQUE INDEX referenced by FOREIGN KEY (https://github.com/sqldelight/sql-psi/pull/732)
 - Fix insert statement exposes columns to a select statement when used as the row source (https://github.com/sqldelight/sql-psi/pull/750)
+- Add rules ANY and ALL for dialects to use as SqlTypes (https://github.com/sqldelight/sql-psi/pull/760)
 
 ## [0.7.3] - 2026-03-13
 [0.7.3]: https://github.com/sqldelight/sql-psi/releases/tag/0.7.3

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -491,3 +491,6 @@ module_argument_name ::= id
 bind_parameter ::= '?'
 table_options ::= table_option ( [COMMA] table_option ) *
 table_option ::= WITHOUT ROWID
+
+any_operator ::= 'ANY' | 'SOME'
+all_operator ::= 'ALL'


### PR DESCRIPTION
These rules are provided for dialects to use as SqlTypes:
`SqlTypes.ANY_OPERATOR`
`SqlTypes.ALL_OPERATOR`

Note:
see https://github.com/sqldelight/sqldelight/pull/6253

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
