### PR TITLE
Fix function_name to support REPLACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add rules ANY and ALL for dialects to use as SqlTypes (https://github.com/sqldelight/sql-psi/pull/760)
 - Update IntelliJ target to 2023.3.1
 - New: Maven coordinates have changed to use `dev.lysine.sql-psi` group ID.
-
+- Support REPLACE as a function name (https://github.com/sqldelight/sql-psi/pull/773)
 
 ## [0.7.3] - 2026-03-13
 [0.7.3]: https://github.com/sqldelight/sql-psi/releases/tag/0.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add rules ANY and ALL for dialects to use as SqlTypes (https://github.com/sqldelight/sql-psi/pull/760)
 - Update IntelliJ target to 2023.3.1
 - New: Maven coordinates have changed to use `dev.lysine.sql-psi` group ID.
-- Support REPLACE as a function name (https://github.com/sqldelight/sql-psi/pull/773)
+- Support keyword-colliding function names REPLACE, LEFT, RIGHT, LIKE, GLOB, IF, MATCH, REGEXP (https://github.com/sqldelight/sql-psi/pull/773)
 
 ## [0.7.3] - 2026-03-13
 [0.7.3]: https://github.com/sqldelight/sql-psi/releases/tag/0.7.3

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -464,7 +464,7 @@ foreign_table ::= id | string {
 }
 identifier ::= id
 pragma_name ::= id
-function_name ::= id
+function_name ::= id | REPLACE
 string_literal ::= string
 table_or_index_name ::= id
 new_table_name ::= id | string {

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -464,7 +464,7 @@ foreign_table ::= id | string {
 }
 identifier ::= id
 pragma_name ::= id
-function_name ::= id | REPLACE
+function_name ::= id | REPLACE | LEFT | RIGHT | LIKE | GLOB | IF | MATCH | REGEXP
 string_literal ::= string
 table_or_index_name ::= id
 new_table_name ::= id | string {

--- a/core/src/testFixtures/resources/fixtures/function-keyword-names/Test.s
+++ b/core/src/testFixtures/resources/fixtures/function-keyword-names/Test.s
@@ -1,0 +1,27 @@
+CREATE TABLE foo (
+  value TEXT
+);
+
+SELECT REPLACE(value, 'foo', 'bar')
+FROM foo;
+
+SELECT LEFT(value, 2)
+FROM foo;
+
+SELECT RIGHT(value, 2)
+FROM foo;
+
+SELECT LIKE(value, 'foo')
+FROM foo;
+
+SELECT GLOB('*oo', value)
+FROM foo;
+
+SELECT IF(value = 'foo', 'yes', 'no')
+FROM foo;
+
+SELECT MATCH(value, 'foo')
+FROM foo;
+
+SELECT REGEXP('f.o', value)
+FROM foo;

--- a/core/src/testFixtures/resources/fixtures/function-replace/Test.s
+++ b/core/src/testFixtures/resources/fixtures/function-replace/Test.s
@@ -1,0 +1,6 @@
+CREATE TABLE foo (
+  value TEXT
+);
+
+SELECT REPLACE(value, 'foo', 'bar')
+FROM foo;

--- a/core/src/testFixtures/resources/fixtures/function-replace/Test.s
+++ b/core/src/testFixtures/resources/fixtures/function-replace/Test.s
@@ -1,6 +1,0 @@
-CREATE TABLE foo (
-  value TEXT
-);
-
-SELECT REPLACE(value, 'foo', 'bar')
-FROM foo;


### PR DESCRIPTION
fixes https://github.com/sqldelight/sqldelight/issues/6109

Uppercase `REPLACE(...)` isn't parsed as a function name because `REPLACE` is a keyword and `function_name ::= id` only accepts `id`. Lowercase `replace(...)` already works.

* Add `REPLACE` as a `function_name` alternative
* Add fixture test
* Tested with SqlDelight locally
