### PR TITLE
Bump intellij to 233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix a compilation error with migration files when CREATE UNIQUE INDEX referenced by FOREIGN KEY (https://github.com/sqldelight/sql-psi/pull/732)
 - Fix insert statement exposes columns to a select statement when used as the row source (https://github.com/sqldelight/sql-psi/pull/750)
 - Add rules ANY and ALL for dialects to use as SqlTypes (https://github.com/sqldelight/sql-psi/pull/760)
+- Update IntelliJ target to 2023.3.1
 
 ## [0.7.3] - 2026-03-13
 [0.7.3]: https://github.com/sqldelight/sql-psi/releases/tag/0.7.3

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+  dependencies {
+    // https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2062
+    classpath(libs.serialization.json)
+  }
+}
+
 plugins {
   alias(libs.plugins.kotlinJvm) apply false
   alias(libs.plugins.spotless)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.grammarkit.tasks.GenerateParserTask
+
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.grammarKitComposer)
@@ -8,6 +10,14 @@ plugins {
 
 grammarKit {
   intellijRelease.set(libs.versions.ideaVersion)
+}
+
+// Constructing CoreApplicationEnvironment on 233+ initializes DisabledPluginsState, which resolves
+// PathManager.getConfigPath() and throws when there is no IDE installation to derive it from.
+// Kotlin contains this same workaround:
+// https://github.com/JetBrains/kotlin/blob/39a9b922d16293bcf7be79c5c7e98edbcf448964/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt#L38-L53
+tasks.withType(GenerateParserTask).configureEach {
+  systemProperty('idea.config.path', 'some/non/existent/path')
 }
 
 sourceSets {

--- a/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
+++ b/environment/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
@@ -9,11 +9,11 @@ import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
 import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.core.CoreProjectEnvironment
 import com.intellij.lang.MetaLanguage
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentIterator
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.roots.impl.CustomEntityProjectModelInfoProvider
 import com.intellij.openapi.roots.impl.DirectoryIndex
 import com.intellij.openapi.roots.impl.DirectoryIndexImpl
 import com.intellij.openapi.roots.impl.ProjectFileIndexImpl
@@ -35,9 +35,22 @@ import com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl
 import java.nio.file.Path
 import kotlin.io.path.pathString
 import kotlin.reflect.KClass
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 private class ApplicationEnvironment {
   val disposable = Disposer.newDisposable()
+
+  init {
+    // Constructing CoreApplicationEnvironment on 233+ initializes DisabledPluginsState, which
+    // resolves PathManager.getConfigPath() and throws when there is no IDE installation to
+    // derive it from. Kotlin contains this same workaround:
+    // https://github.com/JetBrains/kotlin/blob/39a9b922d16293bcf7be79c5c7e98edbcf448964/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt#L38-L53
+    if (System.getProperty(PathManager.PROPERTY_CONFIG_PATH) == null) {
+      System.setProperty(PathManager.PROPERTY_CONFIG_PATH, "some/non/existent/path")
+    }
+  }
 
   val coreApplicationEnvironment: CoreApplicationEnvironment =
     CoreApplicationEnvironment(disposable).apply {
@@ -57,16 +70,13 @@ private class ApplicationEnvironment {
         WorkspaceFileIndexImpl.EP_NAME,
         WorkspaceFileIndexContributor::class.java,
       )
-      CoreApplicationEnvironment.registerApplicationExtensionPoint(
-        CustomEntityProjectModelInfoProvider.EP,
-        CustomEntityProjectModelInfoProvider::class.java,
-      )
     }
 }
 
 open class SqlCoreEnvironment(sourceFolders: List<Path>, dependencies: List<Path>) : AutoCloseable {
   private val fileIndex: CoreFileIndex
 
+  private val coroutineScope = CoroutineScope(SupervisorJob())
   private val env = ApplicationEnvironment()
   protected val projectEnvironment =
     CoreProjectEnvironment(env.disposable, env.coreApplicationEnvironment)
@@ -77,7 +87,7 @@ open class SqlCoreEnvironment(sourceFolders: List<Path>, dependencies: List<Path
   init {
     projectEnvironment.registerProjectComponent(
       ProjectRootManager::class.java,
-      ProjectRootManagerImpl(projectEnvironment.project),
+      ProjectRootManagerImpl(projectEnvironment.project, coroutineScope),
     )
     projectEnvironment.project.registerService(
       WorkspaceFileIndex::class.java,
@@ -207,6 +217,7 @@ open class SqlCoreEnvironment(sourceFolders: List<Path>, dependencies: List<Path
   }
 
   override fun close() {
+    coroutineScope.cancel()
     Disposer.dispose(env.disposable)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # IC sources: https://www.jetbrains.com/intellij-repository/releases
 # choose a matching/similar build
 
-ideaVersion = "231.9423.9" # AS Hedgehog | 2023.1.1
+ideaVersion = "233.14808.21" # AS Jellyfish | 2023.3.1
 kotlin = "2.4.10"
 
 [libraries]
@@ -13,6 +13,7 @@ intellijAnalysisImpl = { module = "com.jetbrains.intellij.platform:analysis-impl
 intellijIndexing = { module = "com.jetbrains.intellij.platform:indexing", version.ref = "ideaVersion" }
 intellijUtilUi = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "ideaVersion" }
 coroutines-core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0"
+serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
 
 junit = "junit:junit:4.13.2"
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
@@ -28,4 +29,4 @@ grammarKitComposer = { id = "app.cash.grammarkit-composer", version = "0.2.0" }
 spotless = { id = "com.diffplug.spotless", version = "8.8.0" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.37.0" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
-intellij = { id = "org.jetbrains.intellij.platform", version = "2.10.4" }
+intellij = { id = "org.jetbrains.intellij.platform", version = "2.18.1" }

--- a/sample-core/build.gradle
+++ b/sample-core/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.grammarkit.tasks.GenerateParserTask
+
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.grammarKitComposer)
@@ -6,6 +8,15 @@ plugins {
 
 grammarKit {
   intellijRelease.set(libs.versions.ideaVersion)
+}
+
+
+// Constructing CoreApplicationEnvironment on 233+ initializes DisabledPluginsState, which resolves
+// PathManager.getConfigPath() and throws when there is no IDE installation to derive it from.
+// Kotlin contains this same workaround:
+// https://github.com/JetBrains/kotlin/blob/39a9b922d16293bcf7be79c5c7e98edbcf448964/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/compat.kt#L38-L53
+tasks.withType(GenerateParserTask).configureEach {
+  systemProperty('idea.config.path', 'some/non/existent/path')
 }
 
 dependencies {

--- a/sample-plugin/build.gradle
+++ b/sample-plugin/build.gradle
@@ -17,8 +17,7 @@ dependencies {
   implementation projects.sampleCore
 
   intellijPlatform {
-    intellijIdeaCommunity('2023.1')
-    instrumentationTools()
+    intellijIdeaCommunity('2023.3')
   }
 }
 


### PR DESCRIPTION
Updates intellij gradle plugin to 2.18.1, which requires a min version of 233+. Everything else is various fixes required by that version bump.

(this is required to also update the intellij gradle plugin for sqldelight)

Closes #752

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
